### PR TITLE
Replace .env with .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-# SAMPLE .env, replace with your actual data
+# SAMPLE .env, copy .env.template to .env and then edit .env with your data to avoid committing secrets
 ANSIBLE_USER=your_initial_ssh_user
 ANSIBLE_PASSWORD=your_initial_password
 SSH_KEY_PATH=/path/to/your/id_rsa.pub

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.env
 .vscode

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ An Ansible playbook for automating secure server setup and configuration with se
    cd basic-server-configuration
    ```
 
-2. Configure environment variables in the `.env` file, you can follow the sample file provided and fill in your data
+2. Configure environment variables in a `.env` file, you can follow the sample file provided in `.env.template` and fill in your data
 
 3. Update the `inventory.ini` file with your server IP addresses:
    ```ini


### PR DESCRIPTION
Hi from /r/selfhosted!

It's better practice to have .env commited to .gitignore and provide a template file. This changes the default behavior to having secrets in an ignored file versus having to be conscious to not commit/push secrets.